### PR TITLE
Fixed compilation errors with ue5-main UE branch.

### DIFF
--- a/Source/PropertyHistory/Private/PropertyHistoryModule.cpp
+++ b/Source/PropertyHistory/Private/PropertyHistoryModule.cpp
@@ -13,18 +13,14 @@
 #include "Editor/PropertyEditor/Private/PropertyHandleImpl.h"
 #include "Editor/PropertyEditor/Private/SDetailSingleItemRow.h"
 #include "Editor/PropertyEditor/Private/DetailRowMenuContextPrivate.h"
+#include "Framework/Docking/TabManager.h"
+#include "Widgets/Docking/SDockTab.h"
 
 DEFINE_PRIVATE_ACCESS(FPropertyNode, InstanceMetaData)
+
 DEFINE_PRIVATE_ACCESS(SDetailsViewBase, DetailLayouts)
 DEFINE_PRIVATE_ACCESS(SDetailTableRowBase, OwnerTreeNode)
 DEFINE_PRIVATE_ACCESS_FUNCTION(SDetailSingleItemRow, GetPropertyNode);
-
-UClass* UDetailRowMenuContextPrivate::GetPrivateStaticClass()
-{
-	static UClass* Class = FindObjectChecked<UClass>(nullptr, TEXT("/Script/PropertyEditor.DetailRowMenuContextPrivate"));
-	check(Class);
-	return Class;
-}
 
 class FPropertyHistoryModule : public IModuleInterface
 {
@@ -160,7 +156,7 @@ public:
 					}
 
 					int32 ArrayIndex = -1;
-					LexFromString(ArrayIndex, Parts[2]);
+					LexFromString(ArrayIndex, *Parts[2]);
 
 					Properties.Add({ Property, ArrayIndex });
 					NumAddedProperties++;

--- a/Source/PropertyHistory/Private/PropertyHistoryUtilities.h
+++ b/Source/PropertyHistory/Private/PropertyHistoryUtilities.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Misc/EngineVersionComparison.h"
 
 #define PROPERTY_HISTORY_ENGINE_VERSION (ENGINE_MAJOR_VERSION * 100 + ENGINE_MINOR_VERSION)
 


### PR DESCRIPTION
- Added explicit include so that the property history preprocessor define would get properly-evaluated engine major/minor values.
- Removed the private class definition in the base module file as it was no longer needed (and failed to compile).
- Added additional includes to resolve some other compiler errors.